### PR TITLE
feat/built in versioning support

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,8 +115,14 @@ import Inertia from '@ioc:EidelLev/Inertia';
 
 Inertia.version('v1');
 
-// Or as a function:
+// You can also pass a function that will be lazily evaluated:
 Inertia.version(() => 'v2');
+```
+
+If you are using Adonis's built-in assets manager `webpack encore` you can also pass the path to the manifest file to Inertia and the current version will be set automatically:
+
+```
+Inertia.version(() => Inertia.manifestFile('public/assets/manifest.json'));
 ```
 
 ### Configuration

--- a/adonis-typings/inertia.ts
+++ b/adonis-typings/inertia.ts
@@ -48,6 +48,13 @@ declare module '@ioc:EidelLev/Inertia' {
      * Asset tracking
      */
     version: (currentVersion: string | number | LazyVersion) => InertiaGlobal;
+
+    /**
+     * Returns md5 hash for manifest file at path
+     * Can be used to automatically determine asset version
+     * @param path manifest file path
+     */
+    manifestFile: (path: string) => string;
   }
 
   const Inertia: InertiaGlobal;

--- a/adonis-typings/route.ts
+++ b/adonis-typings/route.ts
@@ -1,12 +1,15 @@
+import { ResponseProps } from '@ioc:EidelLev/Inertia';
+
 declare module '@ioc:Adonis/Core/Route' {
   interface RouterContract {
     /**
      * Inertia route helper
      *
-     * @param      {string}  pattern    Path
-     * @param      {string}  component  The you'd like inertia to render
+     * @param      {string}         pattern        Path
+     * @param      {string}         component      The component you'd like inertia to render
+     * @param      {ResponseProps}  pageOnlyProps  View metadata that will be passed only to the edge view
      * @return     {RouteContract}
      */
-    inertia: (pattern: string, component: string) => RouterContract;
+    inertia: (pattern: string, component: string, pageOnlyProps: ResponseProps) => RouterContract;
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1780,7 +1780,8 @@
     "@types/he": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@types/he/-/he-1.1.2.tgz",
-      "integrity": "sha512-kSJPcLO1x+oolc0R89pUl2kozldQ/fVQ1C1p5mp8fPoLdF/ZcBvckaTC2M8xXh3GYendXvCpy5m/a2eSbfgNgw=="
+      "integrity": "sha512-kSJPcLO1x+oolc0R89pUl2kozldQ/fVQ1C1p5mp8fPoLdF/ZcBvckaTC2M8xXh3GYendXvCpy5m/a2eSbfgNgw==",
+      "dev": true
     },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.3",
@@ -4708,7 +4709,8 @@
     "he": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
-      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true
     },
     "header-case": {
       "version": "2.0.4",
@@ -4743,6 +4745,11 @@
       "requires": {
         "lru-cache": "^6.0.0"
       }
+    },
+    "html-entities": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.3.2.tgz",
+      "integrity": "sha512-c3Ab/url5ksaT0WyleslpBEthOzWhrjQbg75y7XUsfSzi3Dgzt0l8w5e7DylRn15MTlMMD58dTfzddNS2kcAjQ=="
     },
     "html-escaper": {
       "version": "2.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1819,6 +1819,14 @@
       "integrity": "sha512-cPiXpOvPFDr2edMnOXlz3UBDApwUfR+cpizvxCy0n3vp9bz/qe8BWzHPIEFcy+ogUOyjKuCISgyq77ELZPmkkg==",
       "dev": true
     },
+    "@types/md5": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@types/md5/-/md5-2.3.1.tgz",
+      "integrity": "sha512-OK3oe+ALIoPSo262lnhAYwpqFNXbiwH2a+0+Z5YBnkQEwWD8fk5+PIeRhYA48PzvX9I4SGNpWy+9bLj8qz92RQ==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/minimist": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.1.tgz",
@@ -1828,8 +1836,7 @@
     "@types/node": {
       "version": "14.14.35",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.35.tgz",
-      "integrity": "sha512-Lt+wj8NVPx0zUmUwumiVXapmaLUcAk3yPuHCFVXras9k5VT9TdhJqKqGVUQCD60OTMCl0qxJ57OiTL0Mic3Iag==",
-      "dev": true
+      "integrity": "sha512-Lt+wj8NVPx0zUmUwumiVXapmaLUcAk3yPuHCFVXras9k5VT9TdhJqKqGVUQCD60OTMCl0qxJ57OiTL0Mic3Iag=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",
@@ -2563,6 +2570,11 @@
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
     },
+    "charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc="
+    },
     "check-error": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
@@ -3133,6 +3145,11 @@
         "shebang-command": "^1.2.0",
         "which": "^1.2.9"
       }
+    },
+    "crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs="
     },
     "crypto-random-string": {
       "version": "2.0.0",
@@ -4963,6 +4980,11 @@
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
     },
+    "is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+    },
     "is-ci": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
@@ -5817,6 +5839,16 @@
         "cli-table": "^0.3.1",
         "node-emoji": "^1.10.0",
         "supports-hyperlinks": "^2.1.0"
+      }
+    },
+    "md5": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
+      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
+      "requires": {
+        "charenc": "0.0.2",
+        "crypt": "0.0.2",
+        "is-buffer": "~1.1.6"
       }
     },
     "media-typer": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,9 @@
     "test": "nyc node japaFile.js"
   },
   "dependencies": {
-    "html-entities": "^2.3.2"
+    "@types/md5": "^2.3.1",
+    "html-entities": "^2.3.2",
+    "md5": "^2.3.0"
   },
   "peerDependencies": {
     "@adonisjs/core": ">=5"

--- a/package.json
+++ b/package.json
@@ -40,8 +40,7 @@
     "test": "nyc node japaFile.js"
   },
   "dependencies": {
-    "@types/he": "^1.1.2",
-    "he": "^1.2.0"
+    "html-entities": "^2.3.2"
   },
   "peerDependencies": {
     "@adonisjs/core": ">=5"

--- a/providers/InertiaProvider/InertiaProvider.ts
+++ b/providers/InertiaProvider/InertiaProvider.ts
@@ -79,6 +79,7 @@ export default class InertiaProvider {
     this.app.container.singleton('EidelLev/Inertia', () => ({
       share: Inertia.share,
       version: Inertia.version,
+      manifestFile: Inertia.manifestFile,
     }));
   }
 

--- a/providers/InertiaProvider/InertiaProvider.ts
+++ b/providers/InertiaProvider/InertiaProvider.ts
@@ -1,4 +1,4 @@
-import he from 'he';
+import { encode } from 'html-entities';
 import { ApplicationContract } from '@ioc:Adonis/Core/Application';
 import { HttpContextConstructorContract } from '@ioc:Adonis/Core/HttpContext';
 import { RouterContract } from '@ioc:Adonis/Core/Route';
@@ -23,7 +23,7 @@ export default class InertiaProvider {
    */
   private registerViewGlobal(View: ViewContract) {
     View.global('inertia', (page: Record<string, unknown>) => {
-      return `<div id="app" data-page="${he.escape(JSON.stringify(page))}"></div>`;
+      return `<div id="app" data-page="${encode(JSON.stringify(page))}"></div>`;
     });
   }
 

--- a/providers/InertiaProvider/InertiaProvider.ts
+++ b/providers/InertiaProvider/InertiaProvider.ts
@@ -8,6 +8,7 @@ import { ConfigContract } from '@ioc:Adonis/Core/Config';
 import Validator, { ErrorReporterConstructorContract } from '@ioc:Adonis/Core/Validator';
 import { Inertia } from '../../src/Inertia';
 import { inertiaHelper } from '../../src/inertiaHelper';
+import { ResponseProps } from '@ioc:EidelLev/Inertia';
 
 /*
 |--------------------------------------------------------------------------
@@ -113,9 +114,9 @@ export default class InertiaProvider {
    * Registers the Inertia route helper
    */
   public registerRouteHelper(Route: RouterContract): void {
-    Route.inertia = (pattern: string, component: string) => {
+    Route.inertia = (pattern: string, component: string, pageOnlyProps: ResponseProps = {}) => {
       Route.get(pattern, ({ inertia }) => {
-        return inertia.render(component);
+        return inertia.render(component, {}, pageOnlyProps);
       });
 
       return Route;

--- a/src/Inertia.ts
+++ b/src/Inertia.ts
@@ -1,3 +1,5 @@
+import { readFile } from 'fs/promises';
+import md5 from 'md5';
 import {
   ResponseProps,
   InertiaConfig,
@@ -19,6 +21,18 @@ export class Inertia implements InertiaContract {
   public static share(data: SharedData) {
     Inertia.sharedData = data;
     return Inertia;
+  }
+
+  public static async manifestFile(path: string) {
+    try {
+      const buffer = await readFile(path);
+
+      return md5(buffer);
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.warn('Manifest file could not be read');
+      return '';
+    }
   }
 
   public static version(version: Version) {

--- a/templates/start.txt
+++ b/templates/start.txt
@@ -14,4 +14,4 @@ Inertia.share({
   errors: (ctx) => {
     return ctx.session.flashMessages.get('errors');
   },
-});
+}).version(() => Inertia.manifestFile('public/assets/manifest.json'));


### PR DESCRIPTION
- chore: replaced `he` with `html-entities`
- feat(asset versioning): added manifest file helper to automatically calculate asset version
- feat(route helper): support passing view-only params
