### PR TITLE
fix: redirect back without query string

### DIFF
--- a/src/Inertia.ts
+++ b/src/Inertia.ts
@@ -156,14 +156,12 @@ export class Inertia implements InertiaContract {
     return Object.fromEntries(result);
   }
   /**
-   * @deprecated WARNING: This will be removed in a future release
-   *
-   * Simply replace with Adonis' `response.redirect().back()`
+   * Simply replace with Adonis' `response.redirect().withQs().back()`
    */
   public redirectBack() {
     const { response } = this.ctx;
 
-    response.status(303).redirect().back();
+    response.status(303).redirect().withQs().back();
   }
 
   /**


### PR DESCRIPTION
Add withQs() to redirect back to avoid confusions when using query string.