### PR TITLE
[doc] Add additional dependencies Inertia depends on.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,23 @@ npm i @eidellev/inertia-adonisjs
 yarn add @eidellev/inertia-adonisjs
 ```
 
+Before continuing we need to make sure two additional dependencies exist in our project.
+
+`@adonisjs/view` and `@adonisjs/session`.
+
+```shell
+# NPM
+npm i @adonisjs/view 
+npm i @adonisjs/session
+
+# or Yarn
+yarn add @adonisjs/view
+yarn add @adonisjs/session
+
+# Additionally, we need to configure the packages.
+node ace configure @adonisjs/view
+node ace configure @adonisjs/session
+```
 ## Setup
 
 You can register the package, generate additional files and install additional depdencies by running:


### PR DESCRIPTION
Sometimes developers switch project structure, and change from REST API to InertiaJS, but the documentation here only explains how to Install InertiaJS standalone. 

In the PR I've added some instructions on additional dependencies required to run InertiaJS within AdonisJS. Sadly Adonis and Inertia don't do a good job at catching those type of errors, simply erroring saying the Inertia Module could not be found.

![image](https://user-images.githubusercontent.com/48862659/148574943-8bc2a56d-3982-4da9-aa7b-9f9affcf7f18.png)

This additional documentation could help developers get working with Inertia faster without experiencing these small mistakes that take much time.