### PR TITLE
make sure "app.edge" template load js script properly

### DIFF
--- a/templates/view.txt
+++ b/templates/view.txt
@@ -6,12 +6,13 @@
   <link rel="icon" type="image/png" href="/favicon.ico">
 
   @entryPointStyles('app')
-  @entryPointScripts('app')
 
   <title>{{name}}</title>
   {{inertiaHead}}
 </head>
 <body>
   @inertia
+  
+  @entryPointScripts('app')
 </body>
 </html>


### PR DESCRIPTION
Tested on fresh install `adonisjs` and `inertiajs-adonisjs`, compiled js isn't load properly

The script tag should always be used before the body closes or at the bottom of the HTML file.
The Page will load with HTML and CSS and later JavaScript will load.

Placing scripts at the bottom of the <body> element improves the display speed, because script interpretation slows down the display.

ref: 
- https://stackoverflow.com/questions/436411/where-should-i-put-script-tags-in-html-markup
- https://www.w3schools.com/js/js_whereto.asp