### PR TITLE
fix: use normalized headers

### DIFF
--- a/providers/InertiaProvider/InertiaProvider.ts
+++ b/providers/InertiaProvider/InertiaProvider.ts
@@ -174,7 +174,7 @@ export default class InertiaProvider {
     Response.macro(
       'redirect',
       function (path?: string, forwardQueryString: boolean = false, statusCode = 302): RedirectContract | void {
-        const isInertia = this.request.rawHeaders.includes(HEADERS.INERTIA_HEADER);
+        const isInertia = this.request.headers['x-inertia'];
         const method = this.request.method;
         let finalStatusCode = statusCode;
 

--- a/providers/InertiaProvider/InertiaProvider.ts
+++ b/providers/InertiaProvider/InertiaProvider.ts
@@ -11,7 +11,6 @@ import { ResponseProps } from '@ioc:EidelLev/Inertia';
 import { encode } from 'html-entities';
 import { Inertia } from '../../src/Inertia';
 import { inertiaHelper } from '../../src/inertiaHelper';
-import { HEADERS } from '../../src/utils';
 import InertiaMiddleware from '../../middleware/Inertia';
 
 /*


### PR DESCRIPTION
This PR updates the way we check for the presence of the Inertia header in incoming requests to ensure compatibility with HTTP/2. 

HTTP/2 automatically normalizes all headers to lowercase, so we now access the headers property of the request object and look for the lowercase version of `HEADERS.INERTIA_HEADER` instead of using the `rawHeaders` property.