### PR TITLE
Add SSR live reloading in development

### DIFF
--- a/adonis-typings/inertia.ts
+++ b/adonis-typings/inertia.ts
@@ -80,6 +80,15 @@ declare module '@ioc:EidelLev/Inertia' {
        * @default './inertia/ssr'
        */
       buildDirectory?: string;
+
+      /**
+       * Controls SSR autoreloading when content is changed.
+       *
+       * This should be set to true only during development. In production, you should set this to false for
+       * performance reasons.
+       * @default false
+       */
+      autoreload?: boolean;
     };
   }
 

--- a/src/Inertia.ts
+++ b/src/Inertia.ts
@@ -118,11 +118,16 @@ export class Inertia implements InertiaContract {
   }
 
   private renderSsrPage(page: any): Promise<SsrRenderResult> {
-    const { ssr = { buildDirectory: undefined } } = this.config;
-    const { buildDirectory } = ssr;
+    const { ssr = { buildDirectory: undefined, autoreload: false } } = this.config;
+    const { buildDirectory, autoreload } = ssr;
     const path = buildDirectory || 'inertia/ssr';
+    const ssrModulePath = this.app.makePath(path, 'ssr.js');
 
-    const render = require(this.app.makePath(path, 'ssr.js')).default;
+    if (autoreload) {
+      delete require.cache[ssrModulePath];
+    }
+
+    const render = require(ssrModulePath).default;
 
     return render(page);
   }

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -96,6 +96,7 @@ export async function setupSSR() {
       ssr: {
         enabled: true,
         allowList: ['SomePage'],
+        autoreload: true,
       }
     };`,
   );
@@ -147,6 +148,16 @@ export async function setupSSR() {
   `,
   );
 
+  const changeContent = async (content) =>
+    fs.add(
+      'inertia/ssr/ssr.js',
+      codeBlock`
+    module.exports.default = function render(page) {
+      return {body:'<h1>${content}</h1>', head: ''};
+    }
+  `,
+    );
+
   const app = new Application(fs.basePath, 'web', {
     providers: ['@adonisjs/core', '@adonisjs/view', '@adonisjs/session', '../../providers/InertiaProvider'],
   });
@@ -155,7 +166,7 @@ export async function setupSSR() {
   await app.registerProviders();
   await app.bootProviders();
 
-  return app;
+  return { app, changeContent };
 }
 
 export async function teardown() {


### PR DESCRIPTION
## Context
When the [SSR feature](https://github.com/eidellev/inertiajs-adonisjs/blob/96913aac72f58f23adb1f7fe7d848e4d9e84ff32/README.md#server-side-rendering) is enabled in development,  the [watcher process](https://github.com/eidellev/inertiajs-adonisjs/blob/96913aac72f58f23adb1f7fe7d848e4d9e84ff32/README.md#starting-the-ssr-dev-server) correctly monitors and rebuilds the SSR module during development, so that any change you do to the frontend `Pages` or `Components`, etc is correctly rebuilt and available for being served from the server.

## Problem

I've found that [the current way the SSR is done](https://github.com/eidellev/inertiajs-adonisjs/blob/96913aac72f58f23adb1f7fe7d848e4d9e84ff32/src/Inertia.ts#L120-L128) prevents newly built versions from being picked up after the first SSR operation is performed. 

This means that when reloading the application in the browser, either by `CMD+R` or by the live reload system from Adonis.js itself a small "flicker" will happen, because the browser will have received outdated HTML markup from the server and then it will have been replaced by the CSR rendering on the browser. 

If React's [`hydrateRoot`](https://reactjs.org/docs/react-dom-client.html#hydrateroot) is used instead of [`createRoot`](https://reactjs.org/docs/react-dom-client.html#createroot) (as in the example linked below) then an error is echoed in the browser's console explaining that the CSR generated DOM doesn't match the SSR generated DOM. 

One way to avoid this is to restart the Adonis.js main server/development process so that it picks up the freshly rebuilt version of it, but it's annoying to do after every frontend code change.

## Proposed solution

This Pull Request adds a [new SSR setting](https://github.com/msurdi/inertiajs-adonisjs/blob/2c5fa6521ce3f8771a775b9a1ecadb3778780c7c/adonis-typings/inertia.ts#L91) for this project, named `autoreload` that, when enabled (usually just in development), will then take care of removing from [Node.js' require cache](https://nodejs.org/api/modules.html#requirecache) the already loaded module, so that every time the SSR content is generated it will be done using the latest built frontend code. This happens [here](https://github.com/msurdi/inertiajs-adonisjs/blob/2c5fa6521ce3f8771a775b9a1ecadb3778780c7c/src/Inertia.ts#L126-L132).

I've also included [some tests](https://github.com/msurdi/inertiajs-adonisjs/blob/2c5fa6521ce3f8771a775b9a1ecadb3778780c7c/test/ssr.spec.ts#L48-L98) for this feature, and I've created [this minimal example project](https://github.com/msurdi/inertiajs-adonisjs-issue-example) demonstrating the issue I was having.

## Questions, ideas, etc

* I'm not sure if I was having this problem because I did some wrong setup, missed some docs, etc. Feel free to close this issue if I got it wrong on the first place
* I was on the fence between adding a setting (as I did) or just check if the application is running in development via `NODE_ENV`, etc and avoid the configuration burden for the end user by adding another setting.
* I'm not even sure `autoreload` is descriptive enough for this setting. Any better suggestion?
* I've had to [tweak a bit](https://github.com/msurdi/inertiajs-adonisjs/blob/2c5fa6521ce3f8771a775b9a1ecadb3778780c7c/test/utils.ts#L169) the SSR test utils helper function's return value. Not sure if this is the best approach. I'm happy to change it if you have a better suggestion.
* This probably has some performance impact (which I've not noticed nor measured) but I don't think it would be a big problem because this would be used only during development.

Thanks for your work on this project, and hope you find this interesting or useful enough to get it merged in.
