### PR TITLE
feat(types): add InertiaPage type helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,14 +121,18 @@ export default class UsersController {
       users,
       lazyProp: Inertia.lazy(() => {
         return { lazy: 'too lazy' };
-      })
+      }),
     });
   }
 }
 ```
+
 The data will be loaded on demand by the explicit Inertia visit with option
+
 ```typescript
-{ only: ['lazyProp']}
+{
+  only: ['lazyProp'];
+}
 ```
 
 ## Root template data
@@ -208,6 +212,40 @@ Route.inertia('about', 'About');
 
 // You can also pass root template data as the third parameter:
 Route.inertia('about', 'About', { metadata: '...' });
+```
+
+## TypeScript Helpers
+
+### InertiaPage
+
+Manually typing your front-end components can be tedious and error-prone. This is where the `InertiaPage` type comes in handy.
+
+If you have a controller similar to the following example:
+
+```typescript
+import type { HttpContextContract } from '@ioc:Adonis/Core/HttpContext';
+import { InertiaPage } from '@ioc:EidelLev/Inertia';
+
+export default class FooController {
+  public async index({ inertia }: HttpContextContract) {
+    return inertia.render('Foo', {
+      bar: 'FooBar',
+    });
+  }
+}
+
+// Export this type to use in your front-end components
+export type FooIndexProps = InertiaPage<FooController['index']>;
+```
+
+You can then use the `FooIndexProps` type in your front-end component and get type safety for your props that will update automatically if you change the controller method response params.
+
+```typescript
+import type FooIndexProps from 'App/Controllers/FooController';
+
+const FooPage = ({ bar }: FooIndexProps) => {
+  return <div>{bar}</div>;
+};
 ```
 
 ## Redirects

--- a/adonis-typings/inertia.ts
+++ b/adonis-typings/inertia.ts
@@ -2,8 +2,16 @@ declare module '@ioc:EidelLev/Inertia' {
   import { HttpContextContract } from '@ioc:Adonis/Core/HttpContext';
   import { ResponseContract } from '@ioc:Adonis/Core/Response';
 
-  export type ResponseProps = Record<string, unknown>;
-  export type RenderResponse = Promise<Record<string, unknown> | string | ResponseContract>;
+  type AdonisControllerMethod = (ctx: HttpContextContract, ...args: any) => any;
+  export type ResponseProps = Record<string, any>;
+  type RenderedResponseProps<T extends ResponseProps> = {
+    component: string;
+    version: VersionValue;
+    props: T;
+    url: string;
+  }
+  export type RenderResponse<T extends ResponseProps> = Promise<RenderedResponseProps<T> | string | ResponseContract>;
+  export type InertiaPage<T extends AdonisControllerMethod> = Exclude<Awaited<ReturnType<T>>, string | ResponseContract>['props'];
 
   /**
    * Shared data types
@@ -31,7 +39,7 @@ declare module '@ioc:EidelLev/Inertia' {
      * @param      {string}         component      Page component
      * @param      {ResponseProps}  responseProps  Props
      */
-    render(component: string, responseProps?: ResponseProps, pageOnlyProps?: ResponseProps): RenderResponse;
+    render<T extends ResponseProps>(component: string, responseProps?: T, pageOnlyProps?: ResponseProps): RenderResponse<T>;
 
     /**
      * Redirect back with the correct HTTP status code

--- a/src/Inertia.ts
+++ b/src/Inertia.ts
@@ -49,19 +49,19 @@ export class Inertia implements InertiaContract {
     return new LazyProp(callback);
   }
 
-  public async render(
+  public async render<T extends ResponseProps>(
     component: string,
-    responseProps: ResponseProps = {},
+    responseProps?: T,
     pageOnlyProps: ResponseProps = {},
-  ): RenderResponse {
+  ): RenderResponse<T> {
     const { view: inertiaView, ssr = { enabled: false } } = this.config;
     const { request, response, view, session } = this.ctx;
     const isInertia = request.inertia();
     const partialData = this.resolvePartialData(request.header(HEADERS.INERTIA_PARTIAL_DATA));
     const partialDataComponentHeader = request.header(HEADERS.INERTIA_PARTIAL_DATA_COMPONENT);
     const requestAssetVersion = request.header(HEADERS.INERTIA_VERSION);
-    const props: ResponseProps = await this.resolveProps(
-      { ...Inertia.sharedData, ...responseProps },
+    const props: T = await this.resolveProps(
+      { ...Inertia.sharedData, ...Object(responseProps) },
       partialData,
       component,
       partialDataComponentHeader,


### PR DESCRIPTION
Based off of my enhancement request here https://github.com/eidellev/inertiajs-adonisjs/issues/109

### The Problem 
When using Inertia with Typescript there is currently no type safety when it comes to the frontend framework page that is rendered.  

You can do something like this but we are sort of just faking the type safety here because things can get out of sync

```ts
interface FooPageProps {
   bar: string
}

const FooPage = ({ bar }: FooPageProps) => {
    return <div>{bar}</div>
}
```

Simply by adding some generics to the Inertia.render function we can then create a helper type that can pull the ResponseProps out for us.

So now we can do the following

```ts
import type { HttpContextContract } from '@ioc:Adonis/Core/HttpContext'
import { InertiaPage } from '@ioc:EidelLev/Inertia'

export default class FooController {
  public async index({ inertia }: HttpContextContract) {
 
    return inertia.render('Foo', {
      bar: "FooBar",
    })
  }
}

export type FooIndexProps = InertiaPage<FooController['index']>
```

```ts
import type FooIndexProps from 'App/Controllers/FooController'

const FooPage = ({ bar }: FooIndexProps) => {
    return <div>{bar}</div>
}
```

FooIndexProps now equals
```ts
type FooIndexProps = {
    bar: string
}
```
